### PR TITLE
Eliminate Conjuncts_then2_log

### DIFF
--- a/log.ml
+++ b/log.ml
@@ -51,6 +51,7 @@ and 'a tactic_log =
   | Freeze_then_log of 'a
   | Backchain_tac_log of 'a
   | Imp_subst_tac_log of 'a
+  | Raw_conjuncts_tac_log of 'a
   (* term -> tactic *)
   | Undisch_tac_log of term
   | X_gen_tac_log of term
@@ -61,7 +62,6 @@ and 'a tactic_log =
   | Conv_tac_log of conv
   | Spec_tac_log of term * term
   | X_choose_tac_log of term * 'a
-  | Conjuncts_then2_log of thm_tactic * thm_tactic * 'a
   | Unify_accept_tac_log of term list * 'a
   | Trans_tac_log of 'a * term
   | Asm_meson_tac_log of 'a list
@@ -232,7 +232,7 @@ let tactic_name taclog =
   | Contr_tac_log _ -> "Contr_tac_log"
   | Match_accept_tac_log _ -> "Match_accept_tac_log"
   | Match_mp_tac_log _ -> "Match_mp_tac_log"
-  | Conjuncts_then2_log _ -> "Conjuncts_then2_log"
+  | Raw_conjuncts_tac_log _ -> "Raw_conjuncts_tac_log"
   | Raw_subgoal_tac_log _ -> "Raw_subgoal_tac_log"
   | Freeze_then_log _ -> "Freeze_then_log"
   | X_meta_exists_tac_log _ -> "X_mpeta_exists_tac_log"
@@ -287,6 +287,7 @@ let sexp_tactic_log f taclog =
     | Match_accept_tac_log th
     | Match_mp_tac_log th
     | Backchain_tac_log th
+    | Raw_conjuncts_tac_log th
     | Imp_subst_tac_log th -> Snode [name; f th]
     (* term -> tactic *)
     | Undisch_tac_log tm
@@ -299,8 +300,6 @@ let sexp_tactic_log f taclog =
     | Conv_tac_log c -> Snode [name; sexp_conv c]
     | Spec_tac_log (tm1, tm2) -> Snode [name; sexp_term tm1; sexp_term tm2]
     | X_choose_tac_log (tm, th) -> Snode [name; sexp_term tm; f th]
-    | Conjuncts_then2_log (thm_tac1, thm_tac2, th) ->
-        Snode [name; sexp_thm_tactic thm_tac1; sexp_thm_tactic thm_tac2; f th]
     | Freeze_then_log th -> Snode [name; f th]
     | Unify_accept_tac_log (tml, th) -> Snode [name; Snode (map sexp_term tml); f th]
     | Trans_tac_log (th,tm) -> Snode [name; f th; sexp_term tm]
@@ -358,7 +357,7 @@ let referenced_thms plog =
     | Contr_tac_log th
     | Match_accept_tac_log th
     | Match_mp_tac_log th
-    | Conjuncts_then2_log (_,_,th)
+    | Raw_conjuncts_tac_log th
     | Freeze_then_log th
     | Backchain_tac_log th
     | Imp_subst_tac_log th

--- a/replay.ml
+++ b/replay.ml
@@ -79,9 +79,9 @@ let replay_tactic_log (env : env) log : tactic =
     | Contr_tac_log th -> replay_ttac CONTR_TAC th
     | Match_accept_tac_log th -> replay_ttac MATCH_ACCEPT_TAC th
     | Match_mp_tac_log th -> replay_ttac MATCH_MP_TAC th
+    | Raw_conjuncts_tac_log th -> replay_ttac RAW_CONJUNCTS_TAC th
     (* other *)
     | Conv_tac_log conv -> failwith "TODO: Can't replay Conv_tac_log"
-    | Conjuncts_then2_log (tac1, tac2, th) -> failwith "TODO: Can't replay Conjuncts_then2_log"
     | Raw_subgoal_tac_log tm -> RAW_SUBGOAL_TAC tm
     | Backchain_tac_log th -> replay_ttac (get "BACKCHAIN_TAC" backchain_tac) th
     | Imp_subst_tac_log th -> replay_ttac (get "IMP_SUBST_TAC" imp_subst_tac) th
@@ -93,6 +93,11 @@ let replay_tactic_log (env : env) log : tactic =
 
 exception Hard_failure of string
 let hard_failwith s = raise (Hard_failure s)
+
+let map_error f delay =
+  try delay () with
+      Failure s -> failwith (f s)
+    | Hard_failure s -> hard_failwith (f s)
 
 (* Check that logged goals match goals generated during replay.  This ensures
    failful replay especially when we add or remove hypotheses. *)
@@ -119,15 +124,15 @@ let assert_goals_match: goal -> goal -> unit =
   fun (asl,w) (asl',w') ->
     if length asl != length asl' then
       let show asl = string_of_int (length asl) in
-      failwith ("assert_goals_match: different numbers of hypotheses: " ^
+      hard_failwith ("assert_goals_match: different numbers of hypotheses: " ^
         show asl ^ " != " ^ show asl')
     else (term w w'; List.iter hyp (zip asl asl'));;
 
 let replay_proof_log : src proof_log -> tactic =
   let rec proof n above (env : env) (Proof_log ((asl,_ as g), tac, logs)) g' =
     let above = tactic_name tac :: above in
-    (try assert_goals_match g g'
-     with Failure s -> failwith (s ^ ", stack " ^ String.concat " " (rev above)));
+    map_error (fun s -> s ^ ", stack " ^ String.concat " " (rev above))
+              (fun () -> assert_goals_match g g');
     let rec hyps k env asl = match asl with
         [] -> env
       | (_,a)::asl -> hyps (succ k) (((n,k),a)::env) asl in
@@ -188,7 +193,7 @@ let finalize_proof_log : int -> thm proof_log -> src proof_log = fun before_thms
       | Contr_tac_log th -> Contr_tac_log (thm th)
       | Match_accept_tac_log th -> Match_accept_tac_log (thm th)
       | Match_mp_tac_log th -> Match_mp_tac_log (thm th)
-      | Conjuncts_then2_log (tac1,tac2,th) -> Conjuncts_then2_log (tac1,tac2,thm th)
+      | Raw_conjuncts_tac_log th -> Raw_conjuncts_tac_log (thm th)
       | Raw_subgoal_tac_log tm -> Raw_subgoal_tac_log tm
       | Freeze_then_log th -> Freeze_then_log (thm th)
       | X_meta_exists_tac_log tm -> X_meta_exists_tac_log tm

--- a/tactics.ml
+++ b/tactics.ml
@@ -324,12 +324,10 @@ let (USE_THEN:string->thm_tactic->tactic) =
     ttac th gl;;
 
 let (REMOVE_THEN:string->thm_tactic->tactic) =
-  fun s ttac (asl,w) ->
-    let th = try assoc s asl with Failure _ ->
-             failwith("USE_TAC: didn't find assumption "^s) in
-    let asl1,asl2 = chop_list(index s (map fst asl)) asl in
-    let asl' = asl1 @ tl asl2 in
-    ttac th (asl',w);;
+  fun s ttac (asl,w as g) ->
+    let n,(_,th),asl = try removei ((=) s o fst) asl with Failure _ ->
+                       failwith("USE_TAC: didn't find assumption "^s) in
+    add_tactic_log' g (Raw_pop_tac_log n) (ttac th) (asl,w);;
 
 (* ------------------------------------------------------------------------- *)
 (* General tools to augment a required set of theorems with assumptions.     *)
@@ -656,17 +654,18 @@ let (TRANS_TAC:thm->term->tactic) =
 (* Theorem continuations.                                                    *)
 (* ------------------------------------------------------------------------- *)
 
+(* For easy proof replay *)
+let RAW_CONJUNCTS_TAC: thm_tactic =
+  fun cth g ->
+    null_meta,[g],fun i [th,log] ->
+      let th1,th2 = CONJ_PAIR(INSTANTIATE_ALL i cth) in
+      PROVE_HYP th1 (PROVE_HYP th2 th),
+      Proof_log (g, Raw_conjuncts_tac_log cth, [log])
+
 let (CONJUNCTS_THEN2:thm_tactic->thm_tactic->thm_tactic) =
   fun ttac1 ttac2 cth ->
-      let c1,c2 = dest_conj(concl cth) in
-      fun gl -> let ti,gls,(jfn:justification) = (ttac1(ASSUME c1) THEN ttac2(ASSUME c2)) gl in
-                let jfn' i ths =
-                  let th1,th2 = CONJ_PAIR(INSTANTIATE_ALL i cth) in
-                  (* NOTE: (jfn i ths) will log ttac1 and ttac2, but only with concl of cth. *)
-                  let jth = jfn i ths in
-                  PROVE_HYP th1 (PROVE_HYP th2 (fst jth)),
-                  Proof_log(gl, Conjuncts_then2_log (ttac1, ttac2, cth), [snd jth]) in
-                ti,gls,jfn';;
+    let c1,c2 = dest_conj(concl cth) in
+    RAW_CONJUNCTS_TAC cth THEN ttac1(ASSUME c1) THEN ttac2(ASSUME c2)
 
 let (CONJUNCTS_THEN: thm_tactical) =
   W CONJUNCTS_THEN2;;


### PR DESCRIPTION
Conjuncts_then2_log is now expanded into its component tactics plus a
special Raw_conjuncts_tac_log starter.  This gives us 617 new proofs
in complex.native:

  All proofs:
    total proofs: 21083
    total tactics: 603805 -> 604322

  Replayable proofs:
    total proofs: 8508 -> 9125
    total tactics: 31752 -> 43052

The failure causes are

     6 REPLAY FAILURE: Can't replay Unknown_src in Once_rewrite_tac_log
    22 REPLAY FAILURE: Can't replay Unknown_src in Accept_tac_log
    44 REPLAY FAILURE: Can't replay Unknown_src in Raw_conjuncts_tac_log
    62 REPLAY FAILURE: Can't replay Unknown_src in Rewrite_tac_log
    65 REPLAY FAILURE: Can't replay Unknown_src in X_choose_tac_log
   161 REPLAY FAILURE: Can't replay Unknown_src in Match_mp_tac_log
   274 REPLAY FAILURE: Can't replay Unknown_src in Label_tac_log
  1427 REPLAY FAILURE: Can't replay Unknown_src in Disj_cases_tac_log
  1869 REPLAY FAILURE: Can't replay Unknown_src in Mp_tac_log
  8028 REPLAY FAILURE: TODO: Can't replay Conv_tac_log