### PR TITLE
Removing the dependency on the filename part of conversion.

### DIFF
--- a/log.ml
+++ b/log.ml
@@ -109,34 +109,36 @@ let replace_comb str =
   let tmp = Str.global_replace (Str.regexp "funpow") "FUNPOW" str in
   replace_o tmp
 
+let get_tag_base description str = match Str.split (Str.regexp "[:]") str with
+  | [] -> failwith ("Empty lookup tag for " ^ description)
+  | h :: [] -> h
+  | h :: t -> String.concat ":" t
+
 let lookup_from_registry registry description tag =
   if Hashtbl.mem registry tag then (
     let conv = Hashtbl.find registry tag in
     Printf.printf "Retrieved %s '%s'\n" description tag;
-    let tag_base = (Array.of_list(Str.split (Str.regexp "[:]+") tag)).(1) in
-    (if String.uppercase_ascii tag_base = replace_comb tag_base then
+    (if String.uppercase_ascii tag = replace_comb tag then
        (Printf.printf "Returning retrieved %s: %s\n" description tag;
         conv)
      else failwith (description ^ " is not replayable " ^ tag)))
   else failwith (description ^ " is not found: " ^ tag)
 
-let register_entity registry tag conv =
+let register_entity registry description tag conv =
+  let tag_base = get_tag_base description tag in
+  let tag = tag_base in
   if Hashtbl.mem registry tag then (
     let rconv = Hashtbl.find registry tag in
-    (* Printf.printf "Retrieved conversion '%s'\n" tag; *)
-    let tag = (Array.of_list(Str.split (Str.regexp "[:]+") tag)).(1) in
     (if String.uppercase_ascii tag = replace_comb tag then
-       ((* Printf.printf "Returning retrieved\n"; *)
-       conv) (*rconv here*)
+       conv (*Alternatively: rconv here to check failures immediately*)
      else
-       ((* Printf.printf "Returning original\n"; *)
-       conv)))
+       conv))
   else (
     Hashtbl.replace registry tag conv;
     conv);;
 
-let register_conv = register_entity conversion_registry;;
-let register_conv2conv = register_entity conv2conv_registry;;
+let register_conv = register_entity conversion_registry "conversion";;
+let register_conv2conv = register_entity conv2conv_registry "conv2conv";;
 let lookup_conv = lookup_from_registry conversion_registry "conversion";;
 let lookup_conv2conv =
   lookup_from_registry conv2conv_registry "conv2conv";;

--- a/simp.ml
+++ b/simp.ml
@@ -477,7 +477,7 @@ let ONCE_ASM_REWRITE_RULE thl th =
 let GEN_REWRITE_TAC pstring cnvl thl =
   let cnvl = register_conv2conv pstring cnvl in
   replace_tactic_log
-    (Gen_rewrite_tac_log (pstring, thl))
+    (Gen_rewrite_tac_log ((get_tag_base "conv2conv" pstring), thl))
     (CONV_TAC "simp.ml:(GEN_REWRITE_CONV cnvl thl)" (GEN_REWRITE_CONV cnvl thl));;
 
 let rewrite_log ty thl tac = replace_tactic_log (Rewrite_tac_log (ty,thl)) tac;;

--- a/tactics.ml
+++ b/tactics.ml
@@ -370,7 +370,7 @@ let (CONV_TAC : string -> conv -> tactic) =
   let t_tm = `T` in
   fun args conv ->
   let conv = register_conv args conv in
-  replace_tactic_log (Conv_tac_log args) (fun ((asl,w) as g) ->
+  replace_tactic_log (Conv_tac_log (get_tag_base "conversion" args)) (fun ((asl,w) as g) ->
     let th = conv w in
     let tm = concl th in
     if aconv tm w then ACCEPT_TAC th g else


### PR DESCRIPTION
Per our discussions, CONV_TAC and GEN_REWRITE_TAC should not depend on the file-name part of the  tag. This CL solves this problem by splitting the tag by semicolon and removes the first component of tags in both cases, keeping the rest.