### PR TITLE
Adding proof logging options for printing goal terms and flattening.

### DIFF
--- a/printer.ml
+++ b/printer.ml
@@ -589,12 +589,13 @@ let string_of_thm = print_to_string pp_print_thm;;
 (* ------------------------------------------------------------------------- *)
 
 let rec sexp_term tm =
-  if true then Sleaf ("`" ^ string_of_term tm ^ "`") else  (* For debugging purposes *)
+  if false then Sleaf ("`" ^ string_of_term tm ^ "`") else  (* For debugging purposes *)
   match tm with
     Var (str, ty) -> Snode [Sleaf "v"; sexp_type ty; Sleaf str]
   | Const (str, ty) -> Snode [Sleaf "c"; sexp_type ty; Sleaf str]
   | Comb (t1, t2) -> Snode [Sleaf "a"; sexp_term t1; sexp_term t2]
   | Abs (t1, t2) -> Snode [Sleaf "l"; sexp_term t1; sexp_term t2]
+
 
 let sexp_thm = sexp_memoize (fun th ->
   let tls, tm = dest_thm th in

--- a/tactics.ml
+++ b/tactics.ml
@@ -965,8 +965,8 @@ let (TAC_PROOF : goal * tactic -> thm) =
                                     sexp_src log)
         | None -> ());
       (match tactic_proof_fmt with
-          Some fmt ->  sexp_print fmt (sexp_tac_names log);
-                       pp_print_newline fmt ();
+         Some fmt -> map (sexp_print (fmt !tactics_counter)) (sexp_flat_tac log);
+                     pp_print_newline (fmt !tactics_counter) ()
         | None -> ());
       (* Try to replay proof to ensure log is consistent *)
       (try


### PR DESCRIPTION
Default tactics printing is now flattened, alternating "goal term s-expression; tactic_name;"

Unused functions sexp_tac_names and sexp_term_tac_names are still included to allow tree-style printing of branching tactics.