### PR TITLE
Cloud build scripts

### DIFF
--- a/scripts/cloud-build.sh
+++ b/scripts/cloud-build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -exuo pipefail
+ulimit -s 65536
+
+apt-get update
+apt-get install -y build-essential
+
+mkdir -p build
+pushd build
+
+
+curl -L http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.2.tar.gz -o ocaml-4.04.2.tar.gz
+tar -xzf ocaml-4.04.2.tar.gz
+pushd ocaml-4.04.2
+./configure
+make world.opt
+make install
+popd
+
+curl -L https://github.com/camlp5/camlp5/archive/rel701.tar.gz -o camlp5.tar.gz
+tar -xzf camlp5.tar.gz
+pushd camlp5-rel701
+./configure
+make world.opt
+make install
+cp {main/pcaml,main/quotation,etc/pa_reloc,meta/q_MLast}.{cmi,cmx,o} $(camlp5 -where)
+popd
+
+curl -L https://github.com/brain-research/hol-light/archive/master.tar.gz -o hol-light.tar.gz
+tar -xzf hol-light.tar.gz
+pushd hol-light-master
+make depend
+make native
+popd
+
+popd

--- a/scripts/cloud-build.sh
+++ b/scripts/cloud-build.sh
@@ -9,6 +9,7 @@ mkdir -p build
 pushd build
 
 
+# TODO: vendor dependency sources in GCS for stability
 curl -L http://caml.inria.fr/pub/distrib/ocaml-4.04/ocaml-4.04.2.tar.gz -o ocaml-4.04.2.tar.gz
 tar -xzf ocaml-4.04.2.tar.gz
 pushd ocaml-4.04.2
@@ -26,6 +27,8 @@ make install
 cp {main/pcaml,main/quotation,etc/pa_reloc,meta/q_MLast}.{cmi,cmx,o} $(camlp5 -where)
 popd
 
+# TODO: find a convenient way for users to access hol-light after it
+# is built.
 curl -L https://github.com/brain-research/hol-light/archive/master.tar.gz -o hol-light.tar.gz
 tar -xzf hol-light.tar.gz
 pushd hol-light-master

--- a/scripts/cloud-start.sh
+++ b/scripts/cloud-start.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+: ${BUILD_SCRIPT:=${SCRIPT_DIR}/cloud-build.sh}
+readonly INSTANCE_NAME=${1:-${USER}-hol}
+: ${ZONE:=us-central1-b}
+
+echo "Provisioning GCloud Instance '${INSTANCE_NAME}' on zone ${ZONE}..."
+time gcloud compute instances create \
+  --metadata-from-file startup-script=${BUILD_SCRIPT} \
+  --zone=${ZONE} \
+  ${INSTANCE_NAME}
+
+echo
+echo "Provisioned GCloud Instance '${INSTANCE_NAME}'.  Please give it a few 
+minutes to complete its startup script.  You can...
+  * ssh into the machine with 'gcloud compute ssh ${INSTANCE_NAME}'
+  * monitor the progress of its startup script with 'tail -f /var/log/syslog'
+  * rerun the startup script with
+    'sudo google_metadata_script_runner --script-type startup'
+  * access hol-light under '/build/hol-light-master'
+  * delete the cluster with 'gcloud compute instances delete ${INSTANCE_NAME}'
+  * some permission modification / copying might be necessary to run hol-light
+    as an unpriviliged user.
+"


### PR DESCRIPTION
I wrote some build scripts to get the project up and running on a cloud instance.  It's fairly spartan.  Nothing fancy.

* `scripts/cloud-build.sh` - steps to build hol-light on a cloud machine
* `scripts/cloud-start.sh` - convenience tool to provision a cloud instance and build hol-light